### PR TITLE
Added notes to Ruby example

### DIFF
--- a/identity-services-samples/ruby/controller.rb
+++ b/identity-services-samples/ruby/controller.rb
@@ -1,3 +1,5 @@
+# NOTE: Assumes you're using Devise for authentication.
+
 class SessionsController < Devise::SessionsController  
   def create
     # NOTE: We disable the session storage for XML/JSON requests. API access is handled purely by Token headers

--- a/identity-services-samples/ruby/identity_token.rb
+++ b/identity-services-samples/ruby/identity_token.rb
@@ -35,8 +35,9 @@ class IdentityToken
       nce: nonce
     }
   end
-  
+
   def private_key
+    # NOTE: When saving RSA Private Key as a string, escape line breaks with \n.
     OpenSSL::PKey::RSA.new(ENV['LAYER_PRIVATE_KEY'])
   end
 end


### PR DESCRIPTION
Had a lot of trouble saving RSA Private Key in ENV variables. Added a note to escape new lines with \n when working with Private Key. 

Also added a note that the controller example is using Device.

Hopefully these make the examples clearer for novice Rails developers.